### PR TITLE
Remove redundant (and now incorrect) code for customWorkspace processing.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jobgenerator/JobGenerator.java
+++ b/src/main/java/org/jenkinsci/plugins/jobgenerator/JobGenerator.java
@@ -197,13 +197,6 @@ public class JobGenerator extends Project<JobGenerator, GeneratorRun>
                 if(o.has(k)){ this.autoRunJob = o.getBoolean(k);}
             }
         }
-        
-        if(req.hasParameter("customWorkspace")) {
-            customWorkspace = Util.fixEmptyAndTrim(req.getParameter(
-                                                 "customWorkspace.directory"));
-        } else {
-            customWorkspace = null;
-        }
     }
 
     @Extension


### PR DESCRIPTION
This code was redundant with code executed by the opening super.submit call, and given a recent change in "<p:config-customWorkspace />" in cores 1.585+, it is now incorrect.

This corrects the problem by simply removing the code.
