### PR TITLE
The custom workspace field name was renamed

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jobgenerator/JobGenerator.java
+++ b/src/main/java/org/jenkinsci/plugins/jobgenerator/JobGenerator.java
@@ -317,7 +317,7 @@ public class JobGenerator extends Project<JobGenerator, GeneratorRun>
         }
  
         public FormValidation doCheckCustomWorkspace(
-                @QueryParameter(value="customWorkspace.directory") String customWorkspace){
+                @QueryParameter(value="customWorkspace") String customWorkspace){
             if(Util.fixEmptyAndTrim(customWorkspace)==null)
                 return FormValidation.error(
                               Messages.JobGenerator_CustomWorkspaceEmpty());


### PR DESCRIPTION
Presumably in 1.528. Change breaks backward compatibility, would appreciate a better or improved solution.
