### PR TITLE
Remove JobGenerators own customWorkspace implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.3</version>
+    <version>1.600</version>
   </parent>
 
   <artifactId>jobgenerator</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/jobgenerator/JobGenerator.java
+++ b/src/main/java/org/jenkinsci/plugins/jobgenerator/JobGenerator.java
@@ -70,7 +70,6 @@ public class JobGenerator extends Project<JobGenerator, GeneratorRun>
     private transient boolean processThisJobOnly = false;
     private transient boolean disableJobs = false;
     private transient boolean initiator = false;
-    private transient String customWorkspace = null;
     private String generatedJobName = "";
     private String generatedDisplayJobName = "";
     private boolean autoRunJob = false;
@@ -260,14 +259,6 @@ public class JobGenerator extends Project<JobGenerator, GeneratorRun>
         this.autoRunJob = value;
     }
 
-    public String getCustomWorkspace() {
-        return this.customWorkspace;
-    }
-
-    public void setCustomWorkspace(String customWorkspace) {
-        this.customWorkspace= Util.fixEmptyAndTrim(customWorkspace);
-    }
-
     public boolean getProcessThisJobOnly(){
         return this.processThisJobOnly;
     }
@@ -316,15 +307,6 @@ public class JobGenerator extends Project<JobGenerator, GeneratorRun>
             return FormValidation.validateRequired(value);
         }
  
-        public FormValidation doCheckCustomWorkspace(
-                @QueryParameter(value="customWorkspace.directory") String customWorkspace){
-            if(Util.fixEmptyAndTrim(customWorkspace)==null)
-                return FormValidation.error(
-                              Messages.JobGenerator_CustomWorkspaceEmpty());
-            else
-                return FormValidation.ok();
-        }
-
         public String getDefaultEntriesPage(){
             return getViewPage(FreeStyleProject.class,
                                "configure-entries.jelly");


### PR DESCRIPTION
jenkins-ci core has already implemented customWorkspace in AbstractProject and JobGenerator's own customWorkspace variable overridden it when job configuration was opened and this is why the field was empty.
