### PR TITLE
Added default initialisation of private members

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/jobgenerator/parameters/GeneratorParametersDefinitionProperty.java
+++ b/src/main/java/org/jenkinsci/plugins/jobgenerator/parameters/GeneratorParametersDefinitionProperty.java
@@ -63,16 +63,14 @@ public class GeneratorParametersDefinitionProperty
     private static final Logger LOGGER = Logger.getLogger(
                          GeneratorParametersDefinitionProperty.class.getName());
 
-    private transient List<ParameterDefinition> generatorParameterDefinitions;
-    private transient List<ParameterDefinition> globalParameterDefinitions;
-    private transient List<ParameterDefinition> localParameterDefinitions;
+    private transient List<ParameterDefinition> generatorParameterDefinitions= new ArrayList<ParameterDefinition>();
+    private transient List<ParameterDefinition> globalParameterDefinitions = new ArrayList<ParameterDefinition>();
+    private transient List<ParameterDefinition> localParameterDefinitions = new ArrayList<ParameterDefinition>();
 
     public GeneratorParametersDefinitionProperty(
             ParametersDefinitionProperty property,
             JobGenerator project) {
         this.owner = project;
-        this.generatorParameterDefinitions =
-                                          new ArrayList<ParameterDefinition>();
         List<ParameterDefinition> lpd = property.getParameterDefinitions();
         for(ParameterDefinition pd: lpd){
             if (GeneratorKeyValueParameterDefinition.class.isInstance(pd) ||
@@ -80,8 +78,6 @@ public class GeneratorParametersDefinitionProperty
                 this.generatorParameterDefinitions.add(pd);
             }
         }
-        this.globalParameterDefinitions = new ArrayList<ParameterDefinition>();
-        this.localParameterDefinitions = new ArrayList<ParameterDefinition>();
     }
 
     // required since setOwner is protected.


### PR DESCRIPTION
This fixes NPEs that appear when a property has been serialised for the REST API, such as:

Caused by: java.lang.NullPointerException
        at org.jenkinsci.plugins.jobgenerator.parameters.GeneratorParametersDefinitionProperty$1.size(GeneratorParametersDefinitionProperty.java:203)
        at java.util.AbstractList$Itr.hasNext(AbstractList.java:351)
        at java.util.AbstractCollection.contains(AbstractCollection.java:105)
        at hudson.model.ParametersAction.filter(ParametersAction.java:316)
        at hudson.model.ParametersAction.getParameters(ParametersAction.java:172)
        ... 103 more