### PR TITLE
Restrict for "built-in" label instead of "master" to follow changes in Jenkins CI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.509.3</version>
+    <version>2.319.1</version>
   </parent>
 
   <artifactId>jobgenerator</artifactId>

--- a/src/main/java/org/jenkinsci/plugins/jobgenerator/JobGenerator.java
+++ b/src/main/java/org/jenkinsci/plugins/jobgenerator/JobGenerator.java
@@ -148,7 +148,7 @@ public class JobGenerator extends Project<JobGenerator, GeneratorRun>
 
     @Override
     public Label getAssignedLabel() {
-        return new LabelAtom("master");
+        return new LabelAtom("built-in");
     }
 
     @Override


### PR DESCRIPTION
According to the changelog, Jenkins CI applies the "built-in" label for
the controller node instead of "master", how it was called before:
https://www.jenkins.io/changelog-stable/#v2.319.1

The plugin explicitly defines the "master" as the required label in
code. This behaviour prevents it to be used in new installation with
greater or equal to this Jenkins CI version without explicitly and
manually assigning this label to the controller node too.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
